### PR TITLE
[SOLENG-72] added method to conversations to get transcripts

### DIFF
--- a/drift/conversations.py
+++ b/drift/conversations.py
@@ -20,6 +20,11 @@ class Conversation(object):
         params = {'conversationId': conversation_id}
         return self.client.get(url=url, params=params)
 
+    def get_transcript(self, conversation_id):
+        url = "{}/{}/transcript".format(self.CONVERSATIONS_BASE_URL, conversation_id)
+        params = {'conversationId': conversation_id}
+        return self.client.get(url=url, params=params)
+
     def list(self, limit=50, next_=None):
         url = "{}/{}".format(self.CONVERSATIONS_BASE_URL, "list")
         params = {'limit': limit}


### PR DESCRIPTION
Recently, an endpoint was added to the Drift API to account for retrieval of the conversation transcript, rather than having to parse individual messages into a transcript.

This PR contains the addition of a method to the Conversation class to account for retrieving the transcript.

Risk here is very low, as this method is identical to retrieving a conversation, just with a varying path (parameters are the same).